### PR TITLE
Update links and link checking for 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
+        if: always() && steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report

--- a/README.md
+++ b/README.md
@@ -12,41 +12,39 @@ Sharing _is_ caring. If you think a resource should be added, add a 👍 (`:+1:`
     * Voting Rights: Intimidation
       * [ACLU Voter Intimidation resources (PDF)](https://www.aclu.org/sites/default/files/field_pdf_file/kyr-voterintimidation-v03.pdf)
     * Election Data
-      * [Federal Election Commission Bulk Data](https://www.fec.gov/finance/disclosure/ftpdet.shtml)
-      * [Federal Election Commission Campaign Finance Bulk Data](https://www.fec.gov/portal/download.shtml)
+      * [Federal Election Commission Bulk Data](https://www.fec.gov/data/)
+      * [Federal Election Commission Campaign Finance Bulk Data](https://www.fec.gov/data/browse-data/?tab=bulk-data)
       * Voting and Registration; Voter Turnout
         * [U.S. Census Current Population Survey](https://www.census.gov/topics/public-sector/voting.html)
       * Federal Elections
         * [270toWin](https://www.270towin.com/) - Maps of electoral college votes back to 1789. Also includes voting history and trends by state.
         * [American Presidency Project: Presidential Elections Data](https://www.presidency.ucsb.edu/statistics/elections) - Presidential election data from 1789-present.
-        * [Official state-by-state vote counts in federal elections from 1920 through 2014 from the U.S. House of Representatives.](http://history.house.gov/Institution/Election-Statistics/Election-Statistics/)
-        * [Electoral College Historical Election Votes](https://www.archives.gov/federal-register/electoral-college/historical.html)
+        * [Official state-by-state vote counts in federal elections from 1920 through 2014 from the U.S. House of Representatives.](https://history.house.gov/Institution/Election-Statistics/Election-Statistics/)
+        * [Electoral College Historical Election Votes](https://www.archives.gov/electoral-college)
     * Polls and Studies
-      * [Pew Research Center](https://www.pewresearch.org/topics/elections-and-campaigns/) - Pew Research Center is a nonpartisan fact tank that informs the public about the issues, attitudes and trends shaping America and the world. It does not take policy positions.
+      * [Pew Research Center](https://www.pewresearch.org/topic/politics-policy/us-elections-voters/) - Pew Research Center is a nonpartisan fact tank that informs the public about the issues, attitudes and trends shaping America and the world. It does not take policy positions.
       * [Gallup](https://www.gallup.com/topic/politics.aspx) - Gallup is a polling and market research company
       * [American National Election Studies](https://www.electionstudies.org/) - Data from the American National Election Studies
+    * APIs
+      * [Google Civic Information API](https://developers.google.com/civic-information/) - Election and voter information for U.S. addresses
   * Federal
     * Executive
       * Executive Orders
-        * [Federal Register](https://www.federalregister.gov/executive-orders) - CSV, JSON, and HTML tables available for all orders since 1994.
+        * [Federal Register](https://www.federalregister.gov/presidential-documents/executive-orders) - CSV, JSON, and HTML tables available for all orders since 1994.
     * Legislative
       * Find Your Representatives
-        * [U.S. House of Representatives Lookup](http://www.house.gov/htbin/findrep) - Official House of Representatives Website
+        * [U.S. House of Representatives Lookup](https://www.house.gov/htbin/findrep) - Official House of Representatives Website
         * [U.S. Senate](https://www.senate.gov/senators/contact/) - Official Senate Website
       * Communication Tools
-        * [Contact Congress](https://theunitedstates.io/contact-congress/) - Help create an open data format for Congressional contact forms
+        * [Contact Congress](https://github.com/unitedstates/contact-congress) - Open data format for Congressional contact forms
         * [5 Calls](https://5calls.org/) - Calling is the most effective way to influence your representative.
       * Legislation Tracking
-        * [Congress.gov](https://www.congress.gov/search?q={%22source%22:%22legislation%22}) - Official website for U.S. federal legislative information
+        * [Congress.gov](https://www.congress.gov/search) - Official website for U.S. federal legislative information
         * [govtrack](https://www.govtrack.us/) - GovTrack helps everyone learn about and track the activities of the United States Congress
-        * [Tracking Congress In The Age Of Trump - FiveThirtyEight](https://projects.fivethirtyeight.com/congress-trump-score/votes/)
-      * APIs
-        * Congress
-          * [Congress API by ProPublica](https://propublica.github.io/congress-api-docs/#congress-api-documentation) - Retrieve legislative data from the House of Representatives, the Senate and the Library of 
     * Judicial
       * APIs
-        * [Supreme Court Data in Bulk and Via a REST API](https://free.law/projects/supreme-court-data) - Supreme Court data in bulk and via a REST API
+        * [Supreme Court Data in Bulk and Via a REST API](https://free.law/projects/supreme-court-data/) - Supreme Court data in bulk and via a REST API
   * Whistleblowers
     * Leaking Documents and media
       * [How easy is it to securely leak information to some of America's top news organizations? This easy](https://www.niemanlab.org/2017/01/how-easy-is-it-to-securely-leak-information-to-some-of-americas-top-news-organizations-this-easy/) - Contains a list of Tor Addresses and SecureDrop URLs
-      * [How to Leak to the Internet](https://theintercept.com/2015/01/28/how-to-leak-to-the-intercept/) - Similar to above, but also contains tips on how to protect your own security
+      * [How to Leak to the Intercept](https://theintercept.com/source/) - Similar to above, but also contains tips on how to protect your own security

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Sharing _is_ caring. If you think a resource should be added, add a 👍 (`:+1:`
         * [Contact Congress](https://github.com/unitedstates/contact-congress) - Open data format for Congressional contact forms
         * [5 Calls](https://5calls.org/) - Calling is the most effective way to influence your representative.
       * Legislation Tracking
-        * [Congress.gov](https://www.congress.gov/search) - Official website for U.S. federal legislative information
+        * [Congress.gov](https://www.congress.gov/search?q=%7B%22source%22:%22legislation%22%7D) - Official website for U.S. federal legislative information
         * [govtrack](https://www.govtrack.us/) - GovTrack helps everyone learn about and track the activities of the United States Congress
     * Judicial
       * APIs


### PR DESCRIPTION
This pull request updates several external resource links in the `README.md` file to use current and more accurate URLs, and adds a new API resource. Additionally, it modifies the CI workflow to ensure that issues are always created from link checker failures, even if previous steps fail.

Resource link updates and improvements:

* Updated multiple outdated or broken resource URLs in the `README.md` to point to their latest or more accurate locations, improving link reliability for users.
* Added the "Google Civic Information API" under the APIs section in the `README.md` to provide users with direct access to election and voter information.
* Removed: 
  - FiveThirtyEight Trump Score - Site shut down March 2025, tracker no longer exists
  - ProPublica Congress API - API deprecated, no longer issuing keys

CI workflow improvement:

* Changed the condition for the "Create Issue From File" step in `.github/workflows/ci.yml` to use `always()`, ensuring an issue is created from the link checker report even if previous steps fail.